### PR TITLE
Support phpcs.xml, phpcs.dist.xml and --standard options as part of e…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,7 @@ RUN composer global exec 'which phpcs'
 # List the installed standards.
 RUN composer global exec 'phpcs -i'
 
-# Set the entrypoint to use the Drupal standard.
-ENTRYPOINT ["phpcs", "-p", "--standard=PHPCompatibility"]
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh", "-p"]
+
+CMD ["--report=checkstyle", "--report-file=report/checkstyle.xml", "."]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+
+PHPCS="$(which phpcs)"
+
+# We omit our default --standard=PHPCompatibility option if it is
+# provided some other way at run-time.
+if [[ ! -e phpcs.xml && ! -e phpcs.dist.xml && ! "${@}" == *--standard=* ]]; then
+  PHPCS="$PHPCS --standard=PHPCompatibility"
+fi
+
+eval "${PHPCS} $@"


### PR DESCRIPTION
…ntrypoint

This allows the container to "just work" for devs and jenkins without requiring
the entrypoint to be overridden

The following docker run commands work nicely now without needing to override CMD or ENTRYPOINT:

1. Run compatibility check against my current directory with default settings:

        docker run --rm -v "$(pwd)":"$(pwd)" -w "$(pwd)" computerminds/phpcs-phpcompatibility:latest

2. Run compatibility check against my current directory *correctly honouring the phpcs.xml file* in it (this is default phpcs behaviour):

        docker run --rm -v "$(pwd)":"$(pwd)" -w "$(pwd)" computerminds/phpcs-phpcompatibility:latest

3. Run compatibility check with custom command overrides:

        docker run --rm -v "$(pwd)":"$(pwd)" -w "$(pwd)" computerminds/phpcs-phpcompatibility:latest --standard=SomeOtherStandard --report=checkstyle --report-file=report/checkstyle.xml

Without this PR 2 and 3 are not possible (without overriding the entrypoint)